### PR TITLE
Partial fix for issue #13 - Prevent TVmaze --> Kodi specials syncing …

### DIFF
--- a/script.tvmaze.scrobbler/libs/medialibrary_api.py
+++ b/script.tvmaze.scrobbler/libs/medialibrary_api.py
@@ -95,7 +95,7 @@ def get_episodes(tvshowid, filter_=None):
     """
     params = {
         'tvshowid': tvshowid,
-        'properties': ['season', 'episode', 'playcount', 'tvshowid']
+        'properties': ['season', 'episode', 'uniqueid', 'playcount', 'tvshowid']
     }
     if filter_ is not None:
         params['filter'] = filter_

--- a/script.tvmaze.scrobbler/libs/scrobbling_service.py
+++ b/script.tvmaze.scrobbler/libs/scrobbling_service.py
@@ -146,8 +146,8 @@ def _prepare_episode_list(kodi_episode_list):
     episodes_for_tvmaze = {"direct": [], "indirect": []}
     for episode in kodi_episode_list:
         if  ('uniqueid' in episode
-            and 'tvmaze' in episode['uniqueid']
-            and episode['uniqueid']['tvmaze']):
+             and 'tvmaze' in episode['uniqueid']
+             and episode['uniqueid']['tvmaze']):
             episodes_for_tvmaze["direct"].append({
                 'episode_id': episode['uniqueid']['tvmaze'],
                 'marked_at': int(time.time()),
@@ -227,7 +227,8 @@ def _pull_watched_episodes(kodi_tv_shows=None):
             if (episode['type'] == StatusType.WATCHED
                     and 'season' in tvmaze_episode_info  # Todo: add support for specials
                     and 'number' in tvmaze_episode_info
-                    and tvmaze_episode_info['number'] is not None): # Todo: Remove when support for specials is added
+                    # Todo: Remove when support for specials is added
+                    and tvmaze_episode_info['number'] is not None):
                 filter_ = {
                     'and': [
                         {
@@ -297,7 +298,8 @@ def _push_all_episodes(kodi_tv_shows):
                 logger.warning('TV show "{}" has no episodes'.format(show['label']))
                 continue
             episodes_for_tvmaze = _prepare_episode_list(episodes)
-            if len(episodes_for_tvmaze['direct']) == 0 and len(episodes_for_tvmaze['indirect']) == 0:
+            if (len(episodes_for_tvmaze['direct']) == 0
+                and len(episodes_for_tvmaze['indirect']) == 0):
                 logger.warning('TV show "{}" has no episodes'.format(show['label']))
                 continue
             try:
@@ -353,12 +355,13 @@ def push_single_episode(episode_id):
             'Unable to determine TVmaze id from show info: {}'.format(pformat(tvshow_info)))
         return
     episodes_for_tvmaze = _prepare_episode_list([episode_info])
-    if len(episodes_for_tvmaze['direct']) == 0 and len(episodes_for_tvmaze['indirect']) == 0:
+    if (len(episodes_for_tvmaze['direct']) == 0
+        and len(episodes_for_tvmaze['indirect']) == 0):
         logger.error('Unable to determine TVmaze id from episode info: {}'.format(pformat(episode_info)))
         return
     try:
         if len(episodes_for_tvmaze['direct']) > 0:
-                    tvmaze.push_episodes_direct(episodes_for_tvmaze['direct'])
+            tvmaze.push_episodes_direct(episodes_for_tvmaze['direct'])
         if len(episodes_for_tvmaze['indirect']) > 0:
             tvmaze.push_episodes(episodes_for_tvmaze['indirect'], tvmaze_id)
     except tvmaze.ApiError as exc:
@@ -398,7 +401,8 @@ def _push_recent_episodes(recent_episodes):
             episode_mapping[id_mapping[episode['tvshowid']]].append(episode)
     for tvmaze_id, episodes in six.iteritems(episode_mapping):
         episodes_for_tvmaze = _prepare_episode_list(episodes)
-        if len(episodes_for_tvmaze['direct']) == 0 and len(episodes_for_tvmaze['indirect']) == 0:
+        if (len(episodes_for_tvmaze['direct']) == 0
+            and len(episodes_for_tvmaze['indirect']) == 0):
             logger.error('Unable to determine TVmaze id from episode info: {}'.format(pformat(episodes)))
             continue
         try:

--- a/script.tvmaze.scrobbler/libs/scrobbling_service.py
+++ b/script.tvmaze.scrobbler/libs/scrobbling_service.py
@@ -299,7 +299,7 @@ def _push_all_episodes(kodi_tv_shows):
                 continue
             episodes_for_tvmaze = _prepare_episode_list(episodes)
             if (len(episodes_for_tvmaze['direct']) == 0
-                and len(episodes_for_tvmaze['indirect']) == 0):
+                    and len(episodes_for_tvmaze['indirect']) == 0):
                 logger.warning('TV show "{}" has no episodes'.format(show['label']))
                 continue
             try:
@@ -356,8 +356,9 @@ def push_single_episode(episode_id):
         return
     episodes_for_tvmaze = _prepare_episode_list([episode_info])
     if (len(episodes_for_tvmaze['direct']) == 0
-        and len(episodes_for_tvmaze['indirect']) == 0):
-        logger.error('Unable to determine TVmaze id from episode info: {}'.format(pformat(episode_info)))
+            and len(episodes_for_tvmaze['indirect']) == 0):
+        logger.error(
+            'Unable to determine TVmaze id from episode info: {}'.format(pformat(episode_info)))
         return
     try:
         if len(episodes_for_tvmaze['direct']) > 0:
@@ -402,8 +403,9 @@ def _push_recent_episodes(recent_episodes):
     for tvmaze_id, episodes in six.iteritems(episode_mapping):
         episodes_for_tvmaze = _prepare_episode_list(episodes)
         if (len(episodes_for_tvmaze['direct']) == 0
-            and len(episodes_for_tvmaze['indirect']) == 0):
-            logger.error('Unable to determine TVmaze id from episode info: {}'.format(pformat(episodes)))
+                and len(episodes_for_tvmaze['indirect']) == 0):
+            logger.error(
+                'Unable to determine TVmaze id from episode info: {}'.format(pformat(episodes)))
             continue
         try:
             if len(episodes_for_tvmaze['direct']) > 0:

--- a/script.tvmaze.scrobbler/libs/tvmaze_api.py
+++ b/script.tvmaze.scrobbler/libs/tvmaze_api.py
@@ -36,6 +36,7 @@ USER_API_URL = 'https://api.tvmaze.com/v1'
 AUTH_START_PATH = '/auth/start'
 AUTH_POLL_PATH = '/auth/poll'
 SCROBBLE_SHOWS_PATH = '/scrobble/shows'
+SCROBBLE_EPISODES_PATH = '/scrobble/episodes'
 SHOW_LOOKUP_PATH = '/lookup/shows'
 
 SESSION = requests.Session()
@@ -204,7 +205,7 @@ def poll_authorization(token):
 def push_episodes(episodes, show_id, provider='tvmaze'):
     # type: (List[Dict[Text, int]], Union[int, Text], Text) -> None
     """
-    Send statuses of episodes to TVmase
+    Send statuses of episodes to TVmaze
 
     :param episodes: the list of episodes to update
     :param show_id: TV show ID in tvmaze, thetvdb or imdb online databases
@@ -217,6 +218,18 @@ def push_episodes(episodes, show_id, provider='tvmaze'):
     except requests.HTTPError as exc:
         raise ApiError(response=exc.response)
 
+def push_episodes_direct(episodes):
+    # type: (List[Dict[Text, int]]) -> None
+    """
+    Send statuses of episodes to TVmaze
+
+    :param episodes: the list of episodes to update
+    """
+
+    try:
+        _call_user_api(SCROBBLE_EPISODES_PATH, 'post', authenticate=True, json=episodes)
+    except requests.HTTPError as exc:
+        raise ApiError(response=exc.response)
 
 def get_show_info_by_external_id(show_id, provider):
     # type: (Text, Text) -> DataType


### PR DESCRIPTION
Partial fix for issue #13 

Prevents TVmaze --> Kodi specials syncing from causing errors by skipping them (this should be dealt with at some point, but may be a bigger piece of work).

Fixes Kodi --> TVmaze specials syncing by using the TVmaze Episode ID directly, which is set by the metadata plugin (with fallback to season & episode number in the event that it has not been set).